### PR TITLE
fix: husky hooks execution

### DIFF
--- a/commands/hook.go
+++ b/commands/hook.go
@@ -35,7 +35,7 @@ func executeHook(hookName string) error {
 	}
 
 	// 3. Execute Husky scripts
-	err = executeScriptsInDir(filepath.Join(".husky", hookName))
+	err = executeHuskyGitHook(filepath.Join(".husky/_", hookName))
 	if err != nil {
 		return err
 	}
@@ -77,6 +77,13 @@ func executeScript(path string) error {
 }
 
 func executeStandardGitHook(path string) error {
+	if _, err := os.Stat(path); err == nil {
+		return executeScript(path)
+	}
+	return nil // Hook doesn't exist, which is fine
+}
+
+func executeHuskyGitHook(path string) error {
 	if _, err := os.Stat(path); err == nil {
 		return executeScript(path)
 	}


### PR DESCRIPTION
## Problem

Official way to [setup husky](https://typicode.github.io/husky/get-started.html#husky-init-recommended) is to run `npx husky init`. This commands does two things
1. It creates the following files under directory `.husky/` at the root of your repository and
```md
.husky
├── _
│   ├── applypatch-msg
│   ├── commit-msg
│   ├── h
│   ├── husky.sh
│   ├── post-applypatch
│   ├── post-checkout
│   ├── pre-commit
│   ├── ....
│   └── pre-push
└── pre-commit
```
2. It sets git `core.hooksPath` config to `.husky/_`


With the default setup, git looks for `pre-commit` script under `.husky/_/` directory. This script loads some husky init config files (optional) and then executes `pre-commit` script under `.husky/` if present.


Our code will not work with this default setup, we are looking for husky scripts under `.husky/pre-commit/` directory which doesn't exist.
