### PR TITLE
chore: enforce fine-grain permissions for release-please token

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -21,6 +21,8 @@ jobs:
         with:
           app-id: ${{ vars.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Extract branch name
         shell: bash


### PR DESCRIPTION
Ensure that the generated token has explicit permissions:

```
          permission-contents: write
          permission-pull-requests: write
 ```